### PR TITLE
make default derivation path explicit in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ disk.  bchwallet uses the
 `m/44'/<coin type>'/<account>'/<branch>/<address index>`
 HD path for all derived addresses, as described by
 [BIP0044](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
+The default general derivation path is `m/44'/0'/0'`.
 
 Due to the sensitive nature of public data in a BIP0032 wallet,
 bchwallet provides the option of encrypting not just private keys, but

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ disk.  bchwallet uses the
 `m/44'/<coin type>'/<account>'/<branch>/<address index>`
 HD path for all derived addresses, as described by
 [BIP0044](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
-The default general derivation path is `m/44'/0'/0'`.
+The default general derivation path for a fresh wallet is `m/44'/145'/0'`.
 
 Due to the sensitive nature of public data in a BIP0032 wallet,
 bchwallet provides the option of encrypting not just private keys, but

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ disk.  bchwallet uses the
 `m/44'/<coin type>'/<account>'/<branch>/<address index>`
 HD path for all derived addresses, as described by
 [BIP0044](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
-The default general derivation path for a fresh wallet is `m/44'/145'/0'`.
+The default general derivation path for a fresh wallet is as follows:
+
+ - mainnet: `m/44'/145'/0'` (if you are not sure, this is what you need)
+ - testnet: `m/44'/1'/0'`
+ - simnet: `m/44'/115'/0'`
 
 Due to the sensitive nature of public data in a BIP0032 wallet,
 bchwallet provides the option of encrypting not just private keys, but


### PR DESCRIPTION
re: documentation part of #20 

I followed the whole wallet creation process code path, and I think this is accurate.