### PR TITLE
[Bug] Fix panic in SignRawTransaction when resp.Receive() returns a nil result

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1706,6 +1706,13 @@ func signRawTransaction(icmd interface{}, w *wallet.Wallet, chainClient *chain.R
 		if err != nil {
 			return nil, err
 		}
+
+		// It is possible for result to be nil if the output has already been
+		// spent. Upstream will return nil, nil from the resp.Receive() call.
+		if result != nil {
+			continue
+		}
+
 		script, err := hex.DecodeString(result.ScriptPubKey.Hex)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Addresses issue https://github.com/gcash/bchwallet/issues/43

There is a special case where `resp.Receive()` will return nil, nil. This merely handles that case gracefully by making sure the result is present before decoding `result.ScriptPubKey.Hex`.