### PR TITLE
[Bug] Return error if the input to signRawTransaction is spent

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1710,7 +1710,7 @@ func signRawTransaction(icmd interface{}, w *wallet.Wallet, chainClient *chain.R
 		// It is possible for result to be nil if the output has already been
 		// spent. Upstream will return nil, nil from the resp.Receive() call.
 		if result != nil {
-			continue
+			return nil, errors.New("output spent")
 		}
 
 		script, err := hex.DecodeString(result.ScriptPubKey.Hex)


### PR DESCRIPTION
The last fix to https://github.com/gcash/bchwallet/issues/43 was incomplete. This just causes the method to fail upstream. The better behavior is just to return an error here saying the output was spent.