### PR TITLE
Add prefix for getnewaddress

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -709,7 +709,7 @@ func getNewAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	}
 
 	// Return the new payment address string.
-	return addr.EncodeAddress(), nil
+	return w.ChainParams().CashAddressPrefix+":"+addr.EncodeAddress(), nil
 }
 
 // getRawChangeAddress handles a getrawchangeaddress request by creating


### PR DESCRIPTION
This is part of what is required for #260.  I wanted to do it on one function first and then if correct, I can replicate to the other rpc functions.