### PR TITLE
[Chore] Remove SecretKeyGenerator and improve test suite reliability

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -178,45 +178,11 @@ type unlockDeriveInfo struct {
 	index       uint32
 }
 
-// SecretKeyGenerator is the function signature of a method that can generate
-// secret keys for the address manager.
-type SecretKeyGenerator func(
-	passphrase *[]byte, config *ScryptOptions) (*snacl.SecretKey, error)
-
-// defaultNewSecretKey returns a new secret key.  See newSecretKey.
-func defaultNewSecretKey(passphrase *[]byte,
-	config *ScryptOptions) (*snacl.SecretKey, error) {
-	return snacl.NewSecretKey(passphrase, config.N, config.R, config.P)
-}
-
-var (
-	// secretKeyGen is the inner method that is executed when calling
-	// newSecretKey.
-	secretKeyGen = defaultNewSecretKey
-
-	// secretKeyGenMtx protects access to secretKeyGen, so that it can be
-	// replaced in testing.
-	secretKeyGenMtx sync.RWMutex
-)
-
-// SetSecretKeyGen replaces the existing secret key generator, and returns the
-// previous generator.
-func SetSecretKeyGen(keyGen SecretKeyGenerator) SecretKeyGenerator {
-	secretKeyGenMtx.Lock()
-	oldKeyGen := secretKeyGen
-	secretKeyGen = keyGen
-	secretKeyGenMtx.Unlock()
-
-	return oldKeyGen
-}
-
 // newSecretKey generates a new secret key using the active secretKeyGen.
 func newSecretKey(passphrase *[]byte,
 	config *ScryptOptions) (*snacl.SecretKey, error) {
 
-	secretKeyGenMtx.RLock()
-	defer secretKeyGenMtx.RUnlock()
-	return secretKeyGen(passphrase, config)
+	return snacl.NewSecretKey(passphrase, config.N, config.R, config.P)
 }
 
 // EncryptorDecryptor provides an abstraction on top of snacl.CryptoKey so that

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -1114,26 +1114,9 @@ func testMarkUsed(tc *testContext) bool {
 // testChangePassphrase ensures changes both the public and private passphrases
 // works as intended.
 func testChangePassphrase(tc *testContext) bool {
-	// Force an error when changing the passphrase due to failure to
-	// generate a new secret key by replacing the generation function one
-	// that intentionally errors.
-	testName := "ChangePassphrase (public) with invalid new secret key"
-
-	SetSecretKeyGen(failingSecretKeyGen)
-	err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.rootManager.ChangePassphrase(
-			ns, pubPassphrase, pubPassphrase2, false, fastScrypt,
-		)
-	})
-	if !checkManagerError(tc.t, testName, err, ErrCrypto) {
-		return false
-	}
-
 	// Attempt to change public passphrase with invalid old passphrase.
-	testName = "ChangePassphrase (public) with invalid old passphrase"
-	SetSecretKeyGen(defaultNewSecretKey)
-	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+	testName := "ChangePassphrase (public) with invalid old passphrase"
+	err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 		return tc.rootManager.ChangePassphrase(
 			ns, []byte("bogus"), pubPassphrase2, false, fastScrypt,


### PR DESCRIPTION
The secret key generator swapping code never worked reliably. We have seen numerous errors in the test suite from using this pattern. The problem is when running tests in parallel there is no way to guarantee only 1 test gets the swapped out key generator. 

After looking at the test causing the issue, I don't think it is worth keeping. All it checks is that the SecretKeyGen method bubbles up its errors correctly, and there are other tests that check bubbled up errors from `ChangePassphrase`, and I think those are reasonable enough.

I ripped out the offending code and removed that one test. Now the test suite should be stable.